### PR TITLE
Fix build with Visual Studio 2022

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -13,11 +13,13 @@
 #include <glm/ext.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+#include <array>
+
 struct Preset
 {
   std::string name;
   std::string file;
-  std::string channel[4];
+  std::array <std::string, 4> channel;
 };
 
 class ATTR_DLL_LOCAL CScreensaverShadertoy


### PR DESCRIPTION
Fix build with Visual Studio 2022

In initialization of `g_presets` braces are used for `channel`, then std::array is expected.